### PR TITLE
fix: MySQL "no matching manifest for linux/arm64/v8 in the manifest list entries"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     networks:
       - backend
   inventory_service_db:
+    platform: linux/amd64
     image: mysql:8
     restart: unless-stopped
     container_name: inventory_service_db


### PR DESCRIPTION
As I've tried running the project using Docker on my MacBook Air M1, it showed the error: "no matching manifest for linux/arm64/v8 in the manifest list entries". After mentioning the platform property in docker-compose.yml, it ran okay. 